### PR TITLE
Add makefile to harmonize development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# ignore the mlops folder
+.mlops

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The template contains the following folders/files:
 - mlops/nyc-taxi: a fake pipeline with some basic code.
 - .amlignore: using this file we are removing all the folders and files that are not supposed to be in Azure ML compute.
 - test: unit tests
+- common: common components that can be reused by different projects. This folder should be moved in its own private repository as explained in [the pattern page]().
 
 The template contains the following documents:
 

--- a/common/download.sh
+++ b/common/download.sh
@@ -1,0 +1,7 @@
+#/bin/sh
+JOB_NAME=$1
+WORKSPACE=$2
+RESOURCE_GROUP=$3
+OUTPUT_NAME=$4
+SUB_JOB_NAME=$(az ml job list --parent-job-name $JOB_NAME --query "[?display_name=='train_job'].name" -o tsv --resource-group $RESOURCE_GROUP --workspace-name $WORKSPACE)    
+az ml job download --name ${SUB_JOB_NAME//[$'\r']} --resource-group $RESOURCE_GROUP --workspace-name $WORKSPACE --output-name $OUTPUT_NAME

--- a/common/makefile
+++ b/common/makefile
@@ -1,0 +1,33 @@
+ifneq ($(ENV_FILE),)
+include $(ENV_FILE)
+else
+include config.env
+endif
+
+train:
+	echo [CLOUD] Training with a job pipeline on compute=$(COMPUTE_NAME)
+	az ml job create --set settings.default_compute="azureml:$(COMPUTE_NAME)" \
+	    --file $(JOB_FILE) \
+	    --resource-group $(RESOURCE_GROUP) --workspace-name $(WORKSPACE) \
+	    $(CUSTOM_XARGS) $(private_xargs) $(jenkins_args) 
+	@echo Queued training job
+
+
+
+create-environment:
+	@echo creating environment from $(TRAINING_ENVIRONMENT_FILE)
+	@az ml environment create --file $(TRAINING_ENVIRONMENT_FILE) --resource-group $(RESOURCE_GROUP) --workspace-name $(WORKSPACE)
+	@echo Environment created
+
+download-model:
+	@echo Downloading trained model from output $(OUTPUT_NAME) of job $(JOB_NAME)
+	bash ./.mlops/download.sh $(JOB_NAME) $(WORKSPACE) $(RESOURCE_GROUP) $(OUTPUT_NAME)
+	@echo Downloading trained model completed
+
+get-job:
+	@az ml job show --name $(JOB_NAME) -g $(RESOURCE_GROUP) -w $(WORKSPACE)
+
+test:
+	@echo Running Unit Test
+	@pytest $(TEST_PATH) 
+	@echo Unit Test completed

--- a/config.env
+++ b/config.env
@@ -1,0 +1,13 @@
+COMPUTE_NAME=<compute name for training on AzureML>
+ENVIRONMENT_NAME=<environment name for the create-environment command>
+# The link to the ML Job yaml definition
+JOB_FILE=mlops/nyc-taxi/pipeline.yml
+TRAINING_ENVIRONMENT_FILE=mlops/nyc-taxi/environment.yml
+#The output name of your job for the download-model command
+OUTPUT_NAME=model_output
+JOB_NAME=<Job name for the download-model or the get-job command>
+TEST_PATH=<path to the test source code>
+# Azure ML Workspace settings
+RESOURCE_GROUP=<name of your Azure Machine learning workspace's resource group>
+WORKSPACE_NAME=<name of your Azure Machine learning workspace>
+WORKSPACE_DEFAULT_DATASTORE=<name of your Azure Machine default datastore>

--- a/docs/how_to_setup.md
+++ b/docs/how_to_setup.md
@@ -150,3 +150,37 @@ In order to test the deployed online endpoint, it is possible to [test the endpo
 The number meanings are in the following order:
 
 distance, dropoff_latitude, dropoff_longitude, passengers, pickup_latitude,  pickup_longitude, store_forward, vendor, pickup_weekday, pickup_month, pickup_monthday, pickup_hour, pickup_minute, pickup_second, dropoff_weekday, dropoff_month, dropoff_monthday, dropoff_hour, dropoff_minute, dropoff_second
+
+
+## Using the makefile
+
+The makefile located in the root is an initializer, loading additional targets from a central location (located in the [common folder](../common/) for the demo purpose of this repository), more information is available on the pattern [here]().
+
+A user can initialize the makefile by running the `make init` command which will clone the central makefile with additional targets from the central repository. the makefile will use by default a file name config.env located in the project root as input, it is possible to override the input file location by setting and environment variable named `ENV_FILE` referring to the file path from the root of the directory.
+
+the configuration file is expected to have the following environment variables:
+
+``` .env
+COMPUTE_NAME=<compute name for training on AzureML>
+ENVIRONMENT_NAME=<environment name for the create-environment command>
+# The link to the ML Job yaml definition
+JOB_FILE=mlops/nyc-taxi/pipeline.yml
+TRAINING_ENVIRONMENT_FILE=mlops/nyc-taxi/environment.yml
+#The output name of your job for the download-model command
+OUTPUT_NAME=model_output
+JOB_NAME=<Job name for the download-model or the get-job command>
+TEST_PATH=<path to the test source code>
+# Azure ML Workspace settings
+RESOURCE_GROUP=<name of your Azure Machine learning workspace's resource group>
+WORKSPACE_NAME=<name of your Azure Machine learning workspace>
+WORKSPACE_DEFAULT_DATASTORE=<name of your Azure Machine default datastore>
+```
+
+The example central make targets are the following:
+
+`make train`: Submit a training job to AzureML
+`make create-environment`: Create and environment to AzureML
+`make download-model`: Download the model trained by a particular job from AzureML
+`make get-job`: Get a job from AzureML
+`make test`: Run Unit tests
+

--- a/makefile
+++ b/makefile
@@ -1,0 +1,45 @@
+# this is the repository makefile
+
+-include .mlops/makefile
+
+ifneq ($(ENV_FILE),)
+include $(ENV_FILE)
+else
+include config.env
+endif
+
+MLOPS_REPO_URL?=https://github.com/Mandur/mlops-basic-template-for-azureml-cli-v2.git
+MLOPS_REPO_VERSION=feature/add-makefile
+##################################################################
+## Project specific targets
+##################################################################
+train: train
+##################################################################
+## ML Ops targets (DO NOT MODIFY)
+##################################################################
+
+
+.PHONY: init
+.PHONY: test
+updateTools=false
+ifeq ($(updateTools),true)
+init: -setup-mlops
+else ifeq ($(wildcard .mlops/makefile),)
+init: -setup-mlops
+else
+init:
+endif
+
+..PHONY: -setup-mlops
+-setup-mlops:
+	@echo Running ML Ops setup...
+	@git clone $(MLOPS_REPO_URL) mlops-temp --quiet
+	@cd mlops-temp && git checkout $(MLOPS_REPO_VERSION) --quiet
+ifeq ($(OS),Windows_NT)
+	@IF EXIST .mlops RMDIR /S /Q .mlops
+	@mkdir .mlops && xcopy mlops-temp\common .mlops\ /E/H/Y/Q && rmdir mlops-temp /S /Q
+else
+	@mkdir -p .mlops && cp -r mlops-temp/.mlops .
+	@rm -rf mlops-temp 
+endif
+	@echo Done!

--- a/makefile
+++ b/makefile
@@ -8,8 +8,8 @@ else
 include config.env
 endif
 
-MLOPS_REPO_URL?=https://github.com/Mandur/mlops-basic-template-for-azureml-cli-v2.git
-MLOPS_REPO_VERSION=feature/add-makefile
+MLOPS_REPO_URL?=https://github.com/microsoft/mlops-basic-template-for-azureml-cli-v2.git
+MLOPS_REPO_VERSION=main
 ##################################################################
 ## Project specific targets
 ##################################################################

--- a/mlops/nyc-taxi/environment.yml
+++ b/mlops/nyc-taxi/environment.yml
@@ -1,4 +1,5 @@
 $schema: https://azuremlschemas.azureedge.net/latest/environment.schema.json
 image: mcr.microsoft.com/azureml/openmpi3.1.2-ubuntu18.04
+name: environment_name
 conda_file: conda.yml
 description: Environment created from a Docker image plus Conda environment.


### PR DESCRIPTION
This PR add a makefile to harmonize interaction with Azure ML across project teams. we are supporting the following commands at the moment:

`make train`: Submit a training job to AzureML
`make create-environment`: Create and environment to AzureML
`make download-model`: Download the model trained by a particular job from AzureML
`make get-job`: Get a job from AzureML
`make test`: Run Unit test

There will be follow up work:
* [In this repo] Migration to the Jenkins to the make strategy
* [In the MLOps Solution playbook] a general high-level description of the central usage pattern
